### PR TITLE
docs: reference shared mise configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The official Angular component library for the **D&D Mapp** platform. This repos
 
 ### Prerequisites
 
-This project uses [mise-en-place](https://mise.jdx.dev/) to manage runtime versions locally.
+This project uses [mise-en-place](https://mise.jdx.dev/) to manage runtime versions locally. See the [Mise Configuration Guide](https://github.com/dnd-mapp/.github/blob/main/docs/mise-configuration.md) for global setup instructions.
 
 1. **Install Mise** to automatically manage:
 


### PR DESCRIPTION
## Summary

- Updates the `mise` prerequisite description to link to the shared [Mise Configuration Guide](https://github.com/dnd-mapp/.github/blob/main/docs/mise-configuration.md) for global setup instructions.