### PR TITLE
chore: add symlinks to shared ai-standards docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+../ai-standards/AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+../ai-standards/CLAUDE.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` and `CLAUDE.md` as git symlinks (mode `120000`) pointing to `../ai-standards/AGENTS.md` and `../ai-standards/CLAUDE.md`
- Keeps AI guidance in a single source of truth (`ai-standards` repo) rather than duplicating or drifting per-repo

## Details

Symlinks are stored natively in git with `create mode 120000` and resolve correctly on any platform with symlink support. The relative path (`../ai-standards/...`) works as long as sibling repos share the same parent directory, which matches the standard `dnd-mapp` monorepo layout.

## Test plan

- [ ] Verify `git ls-files -s AGENTS.md CLAUDE.md` shows mode `120000` after checkout
- [ ] Verify the files resolve to the correct content from `ai-standards`

🤖 Generated with [Claude Code](https://claude.com/claude-code)