### PR TITLE
chore: update to latest .github workflow SHAs

### DIFF
--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -22,6 +22,6 @@ jobs:
                   build-storybook: false
 
             - name: Publish package
-              uses: dnd-mapp/.github/.github/actions/publish-npm-package@f41a6251f959b29201d2b8a77da6ae8f1c8bf40d
+              uses: dnd-mapp/.github/.github/actions/publish-npm-package@56033bd95d364655b13fbb1746297b8ef818e876
               with:
                   working-directory: dist/shared-ui

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ permissions:
     contents: write
 jobs:
     release:
-        uses: dnd-mapp/.github/.github/workflows/release.yaml@f41a6251f959b29201d2b8a77da6ae8f1c8bf40d
+        uses: dnd-mapp/.github/.github/workflows/release.yaml@56033bd95d364655b13fbb1746297b8ef818e876
         with:
             version: ${{ inputs.version }}
             prerelease-id: ${{ inputs.prerelease-id }}


### PR DESCRIPTION
## Summary

Updated all action/workflow references to use the latest SHA from the  repo.

## Changes

- 
- 

## Why

The  repo has received updates since the last sync:

- **Security fixes**: CodeQL expression injection fixes in shared Actions
- **New feature**: Git tag signing via GitHub Git Data API

## Notes

No  tag included in commit message.