### PR TITLE
feat: adopt event-driven publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,14 @@
+name: Publish release
+on:
+    push:
+        branches:
+            - main
+            - 'release/**'
+permissions:
+    contents: write
+jobs:
+    publish-release:
+        uses: dnd-mapp/.github/.github/workflows/publish-release.yaml@e447e89f2347766291393f81dc00cbc0877850f5
+        secrets:
+            app-id: ${{ secrets.AUTH_APP_ID }}
+            app-private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}

--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -22,6 +22,6 @@ jobs:
                   build-storybook: false
 
             - name: Publish package
-              uses: dnd-mapp/.github/.github/actions/publish-npm-package@56033bd95d364655b13fbb1746297b8ef818e876
+              uses: dnd-mapp/.github/.github/actions/publish-npm-package@e447e89f2347766291393f81dc00cbc0877850f5
               with:
                   working-directory: dist/shared-ui

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ permissions:
     contents: write
 jobs:
     release:
-        uses: dnd-mapp/.github/.github/workflows/release.yaml@56033bd95d364655b13fbb1746297b8ef818e876
+        uses: dnd-mapp/.github/.github/workflows/release.yaml@e447e89f2347766291393f81dc00cbc0877850f5
         with:
             version: ${{ inputs.version }}
             prerelease-id: ${{ inputs.prerelease-id }}


### PR DESCRIPTION
## Summary

- Adds `publish-release.yaml`: triggers on push to `main` and `release/**`, calls the reusable workflow from `dnd-mapp/.github` to detect a version change and create a signed tag and GitHub Release automatically.
- Updates pinned `dnd-mapp/.github` action/workflow references from `56033bd` → `e447e89`.

## Why

`dnd-mapp/.github#9` reworked the release pipeline so that tag and GitHub Release creation is handled by an event-driven workflow rather than inside `release.yaml`. Each consuming repo must add a `publish-release.yaml` caller and pin to the new commit to get the updated behaviour.